### PR TITLE
Fix issue with non valid SVG shape `svg:rect` -> `rect`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -314,7 +314,7 @@ export class Bitmap {
   toSVG(): string {
     let out = `<svg xmlns:svg="http://www.w3.org/2000/svg" viewBox="0 0 ${this.width} ${this.height}" version="1.1" xmlns="http://www.w3.org/2000/svg">`;
     this.rectRead(0, Infinity, ({ x, y }, val) => {
-      if (val) out += `<svg:rect x = "${x}" y = "${y}" width="1" height="1" />`;
+      if (val) out += `<rect x="${x}" y="${y}" width="1" height="1" />`;
     });
     out += '</svg>';
     return out;


### PR DESCRIPTION
I found an issue while trying to style the SVG output. It would not pick up the styling because it was not a valid shape [https://developer.mozilla.org/en-US/docs/Web/SVG/Element/rect](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/rect).