### PR TITLE
perf(svg): optimize SVG output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -339,7 +339,7 @@ export class Bitmap {
       .join(String.fromCharCode(chCodes.newline));
   }
   toSVG(): string {
-    let out = `<svg xmlns:svg="http://www.w3.org/2000/svg" viewBox="0 0 ${this.width} ${this.height}" version="1.1" xmlns="http://www.w3.org/2000/svg">`;
+    let out = `<svg viewBox="0 0 ${this.width} ${this.height}" version="1.1" xmlns="http://www.w3.org/2000/svg">`;
     // Construct optimized SVG path data.
     let pathData = '';
     let prevPoint: Point | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -339,7 +339,7 @@ export class Bitmap {
       .join(String.fromCharCode(chCodes.newline));
   }
   toSVG(): string {
-    let out = `<svg viewBox="0 0 ${this.width} ${this.height}" version="1.1" xmlns="http://www.w3.org/2000/svg">`;
+    let out = `<svg viewBox="0 0 ${this.width} ${this.height}" xmlns="http://www.w3.org/2000/svg">`;
     // Construct optimized SVG path data.
     let pathData = '';
     let prevPoint: Point | undefined;


### PR DESCRIPTION
Closes #11.

Since there aren't any tests for the `Bitmap.toSVG()` method, I haven't added any with this pull request. Below is a manual comparison between the SVGs generated with and without the changes from this pull request.

SVG generated using 95b78a5, using the string "https://google.com/":
- File: [95b78a5.svg](https://github.com/user-attachments/assets/6e85e9e0-57fc-4ddc-a30c-451ec1835d97)
- String length: 13,546 characters

SVG generated using this pull request, using the same string as above:
- File: [pull-request.svg](https://github.com/user-attachments/assets/72e1fb62-39a5-4cfc-bf55-2a6d94993bd3)
- String length: 3,800 characters (~28.1% of 95b78a5)

Both generated QR codes are visually nearly identical, with the sole difference being the elimination of the hairline gaps between each cell that are present in 95b78a5.
