### PR TITLE
Update the benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,30 +241,52 @@ Future plans:
 
 ## Speed
 
-Benchmarks measured with Apple M4 with node.js 25.
+Benchmarks measured with Apple M4 Pro with node.js 25.
+All numbers are ops/sec (higher is better); 🥇 marks the fastest library in each column.
+Encoders run at ECC level M; an empty cell means the library can't produce that output format natively.
 
-```
-# encode format=ascii
-@paulmillr/qr x 9,050 ops/sec @ 110μs/op
-qrcode-generator x 4,543 ops/sec @ 220μs/op
-nuintun x 3,413 ops/sec @ 292μs/op
+Encoding. Every column encodes the string `HELLO WORLD` (alphanumeric mode), except two:
+_byte_ encodes the URL `https://github.com/paulmillr/qr` — its lowercase letters force 8-bit
+byte mode, since QR's alphanumeric charset only has digits, uppercase and a few symbols —
+and _large_ encodes 768 alphanumeric characters. The columns differ in output format:
 
-# encode format=gif
-@paulmillr/qr x 8,439 ops/sec @ 118μs/op
-qrcode-generator x 2,909 ops/sec @ 343μs/op
-nuintun x 3,470 ops/sec @ 288μs/op
+- **raw**: the library's native matrix / bitmap object (also used for _byte_ and _large_)
+- **ascii**: text rendering for terminals
+- **svg**: SVG string
+- **data-url**: base64 `data:image` URL — note the image format differs per library:
+  PNG for qrcode and lean-qr, GIF for qrcode-generator and nuintun
 
-# encode of large qr
-@paulmillr/qr x 334 ops/sec @ 2ms/op
-qrcode-generator x 174 ops/sec @ 5ms/op
-nuintun x 221 ops/sec @ 4ms/op
+| library            |       raw | raw (byte) | raw (large) |     ascii |       svg |  data-url |
+| ------------------ | --------: | ---------: | ----------: | --------: | --------: | --------: |
+| @paulmillr/qr      |     9,010 |      4,613 |         287 |     9,285 |     8,635 |           |
+| [qrcode-generator] |     5,433 |      2,392 |         170 |     5,272 |     5,539 |     5,042 |
+| [nuintun]          |    19,268 |      8,165 |         443 |           |           |     4,280 |
+| [qrcode]           |    24,417 |  🥇 11,405 |         927 | 🥇 24,421 | 🥇 23,508 |     2,129 |
+| [uqr]              |     6,682 |      3,445 |         319 |     6,554 |     6,338 |           |
+| [lean-qr]          | 🥇 24,492 |     11,283 |    🥇 1,155 |    24,183 |    10,487 | 🥇 20,319 |
 
-# decode
-@paulmillr/qr x 662 ops/sec @ 1ms/op
-jsqr x 50 ops/sec @ 19ms/op
-nuintun x 49 ops/sec @ 20ms/op
-instascan x 128 ops/sec @ 7ms/op ± 31.44% (4ms..166ms)
-```
+Decoding a blurred 756×1008 photo of a QR code:
+
+| library          | decode | avg time |
+| ---------------- | -----: | -------: |
+| @paulmillr/qr    | 🥇 654 |      1ms |
+| [jsqr]           |     48 |     20ms |
+| [nuintun]        |    195 |      5ms |
+| [zxing-wasm]     |    269 |      3ms |
+| [@zxing/library] |    348 |      2ms |
+| [zbar-wasm]      |     65 |     15ms |
+| [instascan]      |    140 |      7ms |
+
+[qrcode-generator]: https://github.com/kazuhikoarase/qrcode-generator
+[nuintun]: https://github.com/nuintun/qrcode
+[qrcode]: https://github.com/soldair/node-qrcode
+[uqr]: https://github.com/unjs/uqr
+[lean-qr]: https://github.com/davidje13/lean-qr
+[jsqr]: https://github.com/cozmo/jsQR
+[zxing-wasm]: https://github.com/Sec-ant/zxing-wasm
+[@zxing/library]: https://github.com/zxing-js/library
+[zbar-wasm]: https://github.com/undecaf/zbar-wasm
+[instascan]: https://github.com/schmich/instascan
 
 ## License
 

--- a/benchmark/thirdparty/index.ts
+++ b/benchmark/thirdparty/index.ts
@@ -9,8 +9,16 @@ import encodeQR from '../../src/index.ts';
 import * as nuintun from '@nuintun/qrcode';
 import * as instascan from 'instascan/src/zxing.js';
 import jsqr from 'jsqr';
+import { readBarcodes } from 'zxing-wasm/reader';
+import zxing from '@zxing/library';
+import { scanImageData } from '@undecaf/zbar-wasm';
 import { fileURLToPath } from 'node:url';
-import * as qrcodeGenerator from 'qrcode-generator';
+import qrcode from 'qrcode-generator';
+import QRCode from 'qrcode';
+import * as uqr from 'uqr';
+import { generate, correction } from 'lean-qr';
+import { toSvgSource } from 'lean-qr/extras/svg';
+import { toPngDataURL } from 'lean-qr/extras/node_export';
 
 const _dirname = dirname(fileURLToPath(import.meta.url));
 const decodeExp = 'https://www.surveymonkey.com/s/TheClubatLAS_T3';
@@ -19,16 +27,37 @@ const decodeJPG = jpeg.decode(
 );
 
 // Compared to other JS libraries:
-// - Don't work: [jsQR](https://github.com/cozmo/jsQR) is dead, [zxing-js](https://github.com/zxing-js/) is [dead](https://github.com/zxing-js/library/commit/b797504c25454db32aa2db410e6502b6db12a401), [qr-scanner](https://github.com/nimiq/qr-scanner/) uses jsQR, doesn't work outside of browser, [qcode-decoder](https://github.com/cirocosta/qcode-decoder) broken version of jsQR, doesn't work outside of browser
-// - Uncool: [instascan](https://github.com/schmich/instascan) is 1MB+ (zxing compiled to js via emscripten), [qrcode](https://github.com/nuintun/qrcode) modern refactor of jsQR (138 stars)
+// - Don't work: [qr-scanner](https://github.com/nimiq/qr-scanner/) uses jsQR, doesn't work outside of browser, [qcode-decoder](https://github.com/cirocosta/qcode-decoder) broken version of jsQR, doesn't work outside of browser
+// - Benched anyway: [jsQR](https://github.com/cozmo/jsQR) unmaintained since 2021 but still the baseline, [zxing-js](https://github.com/zxing-js/library) is NOT dead (shipped 0.23.0 in 2026-04, self-declared maintenance mode), [instascan](https://github.com/schmich/instascan) is 1MB+ (zxing compiled to js via emscripten), [qrcode](https://github.com/nuintun/qrcode) modern refactor of jsQR
+// - WASM engines: [zxing-wasm](https://github.com/Sec-ant/zxing-wasm) is ZXing-C++ via WASM, [@undecaf/zbar-wasm](https://github.com/undecaf/zbar-wasm) is the only maintained ZBar (LGPL-2.1)
 
 const DECODE = {
   '@paulmillr/qr': (jpg) => decodeQR(jpg),
   jsqr: (jpg) => jsqr(jpg.data, jpg.width, jpg.height).data,
   nuintun: (jpg) => {
-    // It corrupts image.data...
-    return new nuintun.Decoder().decode(Uint8Array.from(jpg.data), jpg.width, jpg.height).data;
+    const luminances = nuintun.grayscale(jpg);
+    const matrix = nuintun.binarize(luminances, jpg.width, jpg.height);
+    for (const detected of new nuintun.Detector().detect(matrix)) {
+      try {
+        return new nuintun.Decoder().decode(detected.matrix).content;
+      } catch (e) {}
+    }
+    throw new Error('nuintun: no decodable candidate');
   },
+  'zxing-wasm': async (jpg) => (await readBarcodes(jpg, { formats: ['QRCode'] }))[0].text,
+  '@zxing/library': (jpg) => {
+    // RGBLuminanceSource expects 1-byte-per-pixel luminance, not RGBA
+    const { data, width, height } = jpg;
+    const luminances = new Uint8ClampedArray(width * height);
+    for (let i = 0, j = 0; i < data.length; i += 4, j++)
+      luminances[j] = (data[i] + 2 * data[i + 1] + data[i + 2]) / 4;
+    const source = new zxing.RGBLuminanceSource(luminances, width, height);
+    const bitmap = new zxing.BinaryBitmap(new zxing.HybridBinarizer(source));
+    const hints = new Map();
+    hints.set(zxing.DecodeHintType.POSSIBLE_FORMATS, [zxing.BarcodeFormat.QR_CODE]);
+    return new zxing.MultiFormatReader().decode(bitmap, hints).getText();
+  },
+  'zbar-wasm': async (jpg) => (await scanImageData(jpg))[0].decode(),
   instascan: (jpg) => {
     const ZXing = instascan.default({ TOTAL_MEMORY: 256 * 1024 * 1024 });
     let data = jpg.data;
@@ -51,24 +80,54 @@ const DECODE = {
   },
 };
 
+// All encoders use ECC level M. A library missing a format is skipped in that
+// section, never emulated with wrapper glue.
+const isAlnum = (txt) => /^[0-9A-Z $%*+\-./:]*$/.test(txt);
+const qrcodeGen = (txt) => {
+  const code = qrcode(0, 'M');
+  code.addData(txt, isAlnum(txt) ? 'Alphanumeric' : 'Byte');
+  code.make();
+  return code;
+};
+const nuintunSegment = (txt) =>
+  isAlnum(txt) ? new nuintun.Alphanumeric(txt) : new nuintun.Byte(txt);
+const nuintunEncode = (txt) => new nuintun.Encoder({ level: 'M' }).encode(nuintunSegment(txt));
+// lean-qr defaults to minimal-that-fits ECC, so M must be pinned on both bounds
+const leanQr = (txt) =>
+  generate(txt, { minCorrectionLevel: correction.M, maxCorrectionLevel: correction.M });
+
 const ENCODE = {
-  // paulmillr/qr doesn't support data-url, nuintun doesn't support ascii
-  '@paulmillr/qr': (txt, type) => encodeQR(txt, type, { ecc: 'medium' }),
-  'qrcode-generator': (txt, type) => {
-    const code = qrcodeGenerator.default(0, 'M');
-    code.addData(txt, 'Alphanumeric');
-    code.make();
-    if (type === 'ascii') return code.createASCII(1);
-    else if (type === 'gif') return code.createDataURL();
+  '@paulmillr/qr': {
+    raw: (txt) => encodeQR(txt, 'raw', { ecc: 'medium' }),
+    ascii: (txt) => encodeQR(txt, 'ascii', { ecc: 'medium' }),
+    svg: (txt) => encodeQR(txt, 'svg', { ecc: 'medium' }),
   },
-  nuintun: (txt, type) => {
-    const qrcode = new nuintun.Encoder();
-    qrcode.setEncodingHint(true);
-    qrcode.setErrorCorrectionLevel(nuintun.ErrorCorrectionLevel.M);
-    qrcode.write('你好世界\n');
-    qrcode.write(new nuintun.QRAlphanumeric(txt));
-    qrcode.make();
-    return qrcode.toDataURL();
+  'qrcode-generator': {
+    raw: (txt) => qrcodeGen(txt),
+    ascii: (txt) => qrcodeGen(txt).createASCII(1),
+    svg: (txt) => qrcodeGen(txt).createSvgTag(1, 0),
+    'data-url': (txt) => qrcodeGen(txt).createDataURL(1, 0),
+  },
+  nuintun: {
+    raw: (txt) => nuintunEncode(txt),
+    'data-url': (txt) => nuintunEncode(txt).toDataURL(4),
+  },
+  qrcode: {
+    raw: (txt) => QRCode.create(txt, { errorCorrectionLevel: 'M' }),
+    ascii: (txt) => QRCode.toString(txt, { type: 'utf8', errorCorrectionLevel: 'M' }),
+    svg: (txt) => QRCode.toString(txt, { type: 'svg', errorCorrectionLevel: 'M' }),
+    'data-url': (txt) => QRCode.toDataURL(txt, { errorCorrectionLevel: 'M' }),
+  },
+  uqr: {
+    raw: (txt) => uqr.encode(txt, { ecc: 'M' }),
+    ascii: (txt) => uqr.renderANSI(txt, { ecc: 'M' }),
+    svg: (txt) => uqr.renderSVG(txt, { ecc: 'M' }),
+  },
+  'lean-qr': {
+    raw: (txt) => leanQr(txt),
+    ascii: (txt) => leanQr(txt).toString(),
+    svg: (txt) => toSvgSource(leanQr(txt)),
+    'data-url': (txt) => toPngDataURL(leanQr(txt)),
   },
 };
 
@@ -79,50 +138,73 @@ const percent = (a, b) => `${('' + (a / b) * 100).slice(0, 5)}%`;
 const section = (name) => console.log(`\n# ${name}`);
 
 async function main() {
-  for (const type of ['ascii', 'gif']) {
-    section(`encode format=${type}`);
-    for (const name in ENCODE) {
-      const fn = ENCODE[name];
-      await bench(`${name}`, () => fn('HELLO WORLD', type));
+  for (const type of ['raw', 'ascii', 'svg', 'data-url']) {
+    const inputs =
+      type === 'raw' ? ['HELLO WORLD', 'https://github.com/paulmillr/qr'] : ['HELLO WORLD'];
+    for (const txt of inputs) {
+      section(`encode format=${type} (${isAlnum(txt) ? 'alphanumeric' : 'byte'})`);
+      for (const name in ENCODE) {
+        const fn = ENCODE[name][type];
+        if (!fn) continue;
+        await bench(`${name}`, () => fn(txt));
+      }
     }
   }
-  section('encode of large qr');
+  section('encode of large qr (raw)');
   for (const name in ENCODE) {
-    const fn = ENCODE[name];
-    await bench(`${name}`, () => fn('H'.repeat(768), 'ascii'));
+    const fn = ENCODE[name].raw;
+    if (!fn) continue;
+    await bench(`${name}`, () => fn('H'.repeat(768)));
   }
 
   section('decode');
   for (const name in DECODE) {
     const fn = DECODE[name];
-    await bench(`${name}`, () => deepStrictEqual(fn(decodeJPG), decodeExp));
+    // keep sync decoders promise-free so their timings aren't inflated
+    await bench(`${name}`, () => {
+      const out = fn(decodeJPG);
+      return out instanceof Promise
+        ? out.then((v) => deepStrictEqual(v, decodeExp))
+        : deepStrictEqual(out, decodeExp);
+    });
   }
 
   section('Decoding quality');
   const _dirname = dirname(fileURLToPath(import.meta.url));
   const DETECTION_PATH = pjoin(_dirname, '..', '..', 'test', 'vectors', 'boofcv-v3', 'detection');
 
-  for (const category of listFiles(DETECTION_PATH, true)) {
-    const DIR_PATH = `${DETECTION_PATH}/${category}`;
-    const files = listFiles(DIR_PATH).filter((f) => f.endsWith('.jpg'));
-    const jpg = files.map((f) => jpeg.decode(readFileSync(`${DIR_PATH}/${f}`)));
-    const res = {};
-    for (const name in DECODE) {
-      if (!res[name]) res[name] = 0;
-      for (const img of jpg) {
-        const fn = DECODE[name];
-        try {
-          fn(img);
-          res[name]++;
-        } catch (e) {}
+  // @zxing/library 0.23.0 console.warns a stack trace on every decode miss;
+  // silence just that line so per-category counts stay readable
+  const origWarn = console.warn;
+  console.warn = (...args) => {
+    if (typeof args[0] === 'string' && args[0].startsWith('MultiFormatReader:')) return;
+    origWarn(...args);
+  };
+  try {
+    for (const category of listFiles(DETECTION_PATH, true)) {
+      const DIR_PATH = `${DETECTION_PATH}/${category}`;
+      const files = listFiles(DIR_PATH).filter((f) => f.endsWith('.jpg'));
+      const jpg = files.map((f) => jpeg.decode(readFileSync(`${DIR_PATH}/${f}`)));
+      const res = {};
+      for (const name in DECODE) {
+        if (!res[name]) res[name] = 0;
+        for (const img of jpg) {
+          const fn = DECODE[name];
+          try {
+            await fn(img);
+            res[name]++;
+          } catch (e) {}
+        }
       }
+      console.log(
+        `${category}(${files.length}): `,
+        Object.keys(res)
+          .map((i) => `${i}=${res[i]} (${percent(res[i], files.length)})`)
+          .join(' ')
+      );
     }
-    console.log(
-      `${category}(${files.length}): `,
-      Object.keys(res)
-        .map((i) => `${i}=${res[i]} (${percent(res[i], files.length)})`)
-        .join(' ')
-    );
+  } finally {
+    console.warn = origWarn;
   }
 }
 

--- a/benchmark/thirdparty/package.json
+++ b/benchmark/thirdparty/package.json
@@ -12,11 +12,16 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@nuintun/qrcode": "3.3.0",
-    "@zxing/library": "0.19.2",
+    "@nuintun/qrcode": "5.0.3",
+    "@undecaf/zbar-wasm": "0.11.0",
+    "@zxing/library": "0.23.0",
     "instascan": "1.0.0",
     "jpeg-js": "0.4.4",
     "jsqr": "1.4.0",
-    "qrcode-generator": "1.4.4"
+    "lean-qr": "2.7.2",
+    "qrcode": "1.5.4",
+    "qrcode-generator": "2.0.4",
+    "uqr": "0.1.3",
+    "zxing-wasm": "3.1.2"
   }
 }


### PR DESCRIPTION
I was recently looking for a QRCode generator, and did not know how to evaluate the different ones. I noticed your focus was on speed and you had a benchmark. So I tried to add some of the other big contenders (somewhat recently updated, lots of downloads as per npmx.dev). Pretty surprised by the results!

It seems like **nuintun** has had some progress made since you tested it, as it runs at more ops/sec than this library now. All the while **qrcode-generator** has stood at a standstill and scores the same (within a margin of error) when I test it now versus your previous benchmark run.

As new contenders I added **node-qrcode**, **uqr** (from the unjs org), and **lean-qr**. **uqr** seems to sit somewhere between this library and **qrcode-generator**. But the other two seem to run away with the benchmark in almost all aspects!

I am unclear if there is something about your benchmark, or my changes to it, that happens to favour the strategy of **node-qrcode** and **lean-qr**. Or if they are just that much of an improvement.

For decoding there were some new contenders as well, not in the least the updated **@zxing/library**. While that one came close with a 2ms average operation time, your library still easily wins that benchmark.

I am not sure how you feel about showing up benchmarks where you are no longer the fastest. But I think it is always good to show current day competition and not have benchmarks stuck in the past. This was essential for me in looking for a library.